### PR TITLE
Fix modal button dimensions to be square (32px)

### DIFF
--- a/style.css
+++ b/style.css
@@ -1185,7 +1185,7 @@ textarea {
 .add-category-badge[data-category="4"] { background-color: #ffcdd2; border-left: 2px solid #E57373; }
 .add-category-badge[data-category="5"] { background-color: #d1c4e9; border-left: 2px solid #9575CD; }
 
-/* Кнопка активаии/деактивации всей категории в зголовке группы */
+/* Кн��пка активаии/деактивации всей категории в зголовке группы */
 .category-title .subcategory-toggle-all { margin-left: 6px; }
 
 /* ��нопки на секциях главного экрана */
@@ -1252,7 +1252,7 @@ textarea {
 .modal-backdrop { position: absolute; inset: 0; background: rgba(0,0,0,0.35); }
 .modal-content { position: relative; background: white; border-radius: 10px; padding: 28px 16px 16px; width: 92%; max-width: 520px; max-height: 88vh; overflow-y: auto; box-shadow: 0 6px 20px rgba(0,0,0,0.25); }
 .modal-content h3 { font-family: 'Caveat', cursive; font-size: 1.6rem; color: #5d4037; margin-bottom: 8px; }
-.modal-close { position: absolute; top: 8px; right: 8px; width: 36px; height: 36px; aspect-ratio: 1 / 1; display: inline-flex; align-items: center; justify-content: center; background: rgba(0,0,0,0.04); border-radius: 8px; border: none; font-size: 1.0rem; line-height: 1; padding: 0; cursor: pointer; color: #5d4037; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+.modal-close { position: absolute; top: 8px; right: 8px; width: 32px; height: 32px; aspect-ratio: 1 / 1; display: inline-flex; align-items: center; justify-content: center; background: rgba(0,0,0,0.04); border-radius: 8px; border: none; font-size: 1.0rem; line-height: 1; padding: 0; cursor: pointer; color: #5d4037; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
 .modal-close:active { transform: scale(0.98); }
 .modal-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 12px; }
 
@@ -1604,7 +1604,7 @@ textarea {
 @media (min-width: 1024px) {
     /* Make sections flex columns so .section-actions with margin-top:auto aligns to bottom */
     .section { display: flex; flex-direction: column; }
-    /* Выронять элементы задачи в сетку: т��кст сле��а, справа сверх категория, снизу под ней кнопки */
+    /* Выронять элементы задачи в сетку: ����кст сле��а, справа сверх категория, снизу под ней кнопки */
     .task {
         display: grid;
         grid-template-columns: 1fr auto;

--- a/style.css
+++ b/style.css
@@ -1159,7 +1159,7 @@ textarea {
     .group-grid .task-controls { grid-column: 2 / 3; grid-row: 2 / 3; margin: 0; justify-content: flex-end; }
 }
 
-/* Скрыти задач при свёрнутой группе */
+/* Скрыти з��дач при свёрнутой группе */
 .category-group.collapsed .group-grid { display: none; }
 
 /* Цвет и иконка caret на бейдже категории задач */
@@ -1252,7 +1252,7 @@ textarea {
 .modal-backdrop { position: absolute; inset: 0; background: rgba(0,0,0,0.35); }
 .modal-content { position: relative; background: white; border-radius: 10px; padding: 28px 16px 16px; width: 92%; max-width: 520px; max-height: 88vh; overflow-y: auto; box-shadow: 0 6px 20px rgba(0,0,0,0.25); }
 .modal-content h3 { font-family: 'Caveat', cursive; font-size: 1.6rem; color: #5d4037; margin-bottom: 8px; }
-.modal-close { position: absolute; top: 8px; right: 8px; width: 32px; height: 32px; aspect-ratio: 1 / 1; display: inline-flex; align-items: center; justify-content: center; background: rgba(0,0,0,0.04); border-radius: 8px; border: none; font-size: 1.0rem; line-height: 1; padding: 0; cursor: pointer; color: #5d4037; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+.modal-close { position: absolute; top: 8px; right: 8px; width: 32px; height: 32px; min-width: 32px; min-height: 32px; aspect-ratio: 1 / 1; display: inline-flex; align-items: center; justify-content: center; background: rgba(0,0,0,0.04); border-radius: 8px; border: none; font-size: 1.0rem; line-height: 1; padding: 0; cursor: pointer; color: #5d4037; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
 .modal-close:active { transform: scale(0.98); }
 .modal-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 12px; }
 
@@ -1554,7 +1554,7 @@ textarea {
     }
 }
 
-/* Медиа-запрос ля планшетов и больших телефонов */
+/* Медиа-запрос ля планше��ов и больших телефонов */
 @media (min-width: 481px) {
     body {
         padding: 15px;

--- a/style.css
+++ b/style.css
@@ -1159,13 +1159,13 @@ textarea {
     .group-grid .task-controls { grid-column: 2 / 3; grid-row: 2 / 3; margin: 0; justify-content: flex-end; }
 }
 
-/* Скрыти з��дач при свёрнутой группе */
+/* Скрыт�� з��дач при свёрнутой группе */
 .category-group.collapsed .group-grid { display: none; }
 
 /* Цвет и иконка caret на бейдже категории задач */
 .category-badge i { color: #5d4037; }
 
-/* Группировк опций в выпадающих списках категорий */
+/* Группиро��к опций в выпадающих списках категорий */
 .category-option-group { padding-top: 6px; }
 .category-option-group { margin-top: 4px; margin-bottom: 4px; position: relative; }
 .category-option-group > .category-option { width: 100%; border-bottom-left-radius: 0; border-bottom-right-radius: 0; padding: 3px 8px; font-size: 0.9rem; line-height: 1.1; min-height: 28px; display: flex; align-items: center; justify-content: center; }
@@ -1451,7 +1451,7 @@ textarea {
 /* Selected chip — subtle outline */
 .modal-subcat-chip.selected { outline: 2px solid rgba(0,0,0,0.12); }
 /* Minimal + button */
-.add-subcategory-controls .add-subcategory-plus { width: 32px; height: 32px; padding: 0; background: transparent; border: 1px solid rgba(0,0,0,0.12); color: #5d4037; display: inline-flex; align-items: center; justify-content: center; border-radius: 50%; flex: 0 0 auto; }
+.add-subcategory-controls .add-subcategory-plus { width: 32px; height: 32px; min-width: 32px; min-height: 32px; aspect-ratio: 1 / 1; padding: 0; background: transparent; border: 1px solid rgba(0,0,0,0.12); color: #5d4037; display: inline-flex; align-items: center; justify-content: center; border-radius: 50%; flex: 0 0 auto; }
 .add-subcategory-controls .add-subcategory-plus:active { transform: scale(0.96); background: rgba(0,0,0,0.06); }
 .add-subcategory-controls .add-subcategory-plus i { pointer-events: none; font-size: 1rem; line-height: 1; }
 /* Hidden inline editor (appears after pressing +) */


### PR DESCRIPTION
## Purpose

The user requested UI improvements to make buttons in the modal window properly square-shaped with consistent dimensions. Specifically, they wanted:
1. The modal close button (×) to be exactly 32px × 32px instead of rectangular
2. The add subcategory button (+) to be perfectly circular with 1:1 aspect ratio instead of vertically oval

## Code changes

- **Modal close button**: Updated `.modal-close` to use `width: 32px; height: 32px` (down from 36px) and added `min-width` and `min-height` properties to ensure consistent square dimensions
- **Add subcategory button**: Enhanced `.add-subcategory-plus` with `min-width`, `min-height`, and `aspect-ratio: 1 / 1` properties to guarantee a perfect circle shape

Both buttons now maintain their intended geometric shapes across different screen sizes and browser conditions.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1d2fcaef8a8d42d9aff26cf1e04c625a/pixel-field)

👀 [Preview Link](https://1d2fcaef8a8d42d9aff26cf1e04c625a-pixel-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1d2fcaef8a8d42d9aff26cf1e04c625a</projectId>-->
<!--<branchName>pixel-field</branchName>-->