### PR TITLE
Fix: Adjust timer background image scaling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "korobochka",
-  "version": "4.1",
+  "version": "4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "korobochka",
-      "version": "4.1",
+      "version": "4.4",
       "license": "MIT",
       "dependencies": {
         "web-push": "^3.6.7"

--- a/style.css
+++ b/style.css
@@ -581,7 +581,7 @@ textarea {
     max-width: 350px;
     padding: 20px 15px;
     background-color: rgba(255, 255, 255, 0.85);
-    background-size: contain;
+    background-size: cover;
     background-position: center center;
     background-attachment: scroll;
     background-repeat: no-repeat;


### PR DESCRIPTION
### Purpose

The user wanted to change the scaling of the timer's background image. The goal was to make the image cover the entire timer window, cropping it if necessary, instead of fitting it completely within the window.

### Code changes

- In `style.css`, the `background-size` property for the timer window was changed from `contain` to `cover`.
- The version in `package-lock.json` was updated.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/973e437a787b4fdda2bac24ce76015f4/flare-field)

👀 [Preview Link](https://973e437a787b4fdda2bac24ce76015f4-flare-field.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 43`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>973e437a787b4fdda2bac24ce76015f4</projectId>-->
<!--<branchName>flare-field</branchName>-->