### PR TITLE
Style: Set timer background to cover

### DIFF
--- a/script.js
+++ b/script.js
@@ -1219,7 +1219,7 @@ function showTimer(task) {
 
         if (backgroundImage) {
             timerContent.style.backgroundImage = `url('${backgroundImage}')`;
-            timerContent.style.backgroundSize = 'contain';
+            timerContent.style.backgroundSize = 'cover';
             timerContent.style.backgroundPosition = 'center center';
             timerContent.style.backgroundRepeat = 'no-repeat';
             timerContent.style.backgroundAttachment = 'scroll';


### PR DESCRIPTION
### Purpose

Based on the conversation, the user wants to adjust the timer's background image. The key requirements are:
- The image should fill the entire timer rectangle.
- No white stripes should be visible at the edges.
- The image should be cropped (not stretched or shrunk) if the aspect ratio doesn't match.
- The center of the image should always be in focus.

### Code changes

- In `script.js`, the `background-size` CSS property for the timer's background image was changed from `contain` to `cover`. This change makes the image scale to fill the container, cropping the edges as needed, which fulfills the user's visual requirements.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/973e437a787b4fdda2bac24ce76015f4/quantum-oasis)

👀 [Preview Link](https://973e437a787b4fdda2bac24ce76015f4-quantum-oasis.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 44`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>973e437a787b4fdda2bac24ce76015f4</projectId>-->
<!--<branchName>quantum-oasis</branchName>-->