### PR TITLE
Fix: Animate only changing timer digits

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,9 @@
             <h2>Ваша задача:</h2>
             <div class="timer-task" id="timerTaskText"></div>
             <div class="timer-category-info" id="timerCategoryInfo"></div>
-            <div class="timer-display" id="timerDisplay">15:00</div>
+            <div class="timer-display" id="timerDisplay">
+                <span class="timer-digit" data-digit="0">1</span><span class="timer-digit" data-digit="1">5</span><span class="timer-separator">:</span><span class="timer-digit" data-digit="2">0</span><span class="timer-digit" data-digit="3">0</span>
+            </div>
             
             <div class="timer-controls">
                 <div class="timer-settings-row">

--- a/script.js
+++ b/script.js
@@ -1357,15 +1357,23 @@ function hideTimer() {
 function updateTimerDisplay() {
     const minutes = Math.floor(timerTime / 60);
     const seconds = timerTime % 60;
-    const newText = `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
-    const oldText = timerDisplay.textContent;
+    const formattedMinutes = minutes.toString().padStart(2, '0');
+    const formattedSeconds = seconds.toString().padStart(2, '0');
+    const newDigits = [formattedMinutes[0], formattedMinutes[1], formattedSeconds[0], formattedSeconds[1]];
 
-    if (oldText !== newText) {
-        timerDisplay.classList.remove('digit-animate');
-        timerDisplay.textContent = newText;
-        void timerDisplay.offsetWidth;
-        timerDisplay.classList.add('digit-animate');
-    }
+    const digitElements = timerDisplay.querySelectorAll('.timer-digit');
+
+    digitElements.forEach((element, index) => {
+        const oldValue = element.textContent;
+        const newValue = newDigits[index];
+
+        if (oldValue !== newValue) {
+            element.classList.remove('digit-animate');
+            element.textContent = newValue;
+            void element.offsetWidth;
+            element.classList.add('digit-animate');
+        }
+    });
 }
 
 // Функция для показа уведомления

--- a/style.css
+++ b/style.css
@@ -636,6 +636,16 @@ textarea {
     line-height: 1;
 }
 
+.timer-digit {
+    display: inline-block;
+    min-width: 0.6em;
+}
+
+.timer-separator {
+    display: inline-block;
+    padding: 0 0.1em;
+}
+
 .timer-task {
     font-size: 1.3rem;
     margin-bottom: 12px;


### PR DESCRIPTION
### Purpose

The user wanted to improve the timer animation. Instead of all digits re-animating every second, the goal is to animate only the digits that actually change value.

### Code changes

- **`index.html`**: The timer display is now composed of individual `<span>` elements for each digit and the separator, allowing for individual animation.
- **`script.js`**: The `updateTimerDisplay` function was updated to check each digit separately. It now applies the animation class only to the digits that have changed.
- **`style.css`**: Added styles for `.timer-digit` and `.timer-separator` to correctly display the new structure.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/973e437a787b4fdda2bac24ce76015f4/pixel-studio)

👀 [Preview Link](https://973e437a787b4fdda2bac24ce76015f4-pixel-studio.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 46`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>973e437a787b4fdda2bac24ce76015f4</projectId>-->
<!--<branchName>pixel-studio</branchName>-->