### PR TITLE
Fix: Timer background images not displaying correctly

### DIFF
--- a/script.js
+++ b/script.js
@@ -1236,11 +1236,13 @@ function showTimer(task) {
         const backgroundImage = getRandomBackgroundForCategory(task.category);
 
         if (backgroundImage) {
-            timerContent.style.backgroundImage = `url('${backgroundImage}')`;
+            // Apply background image with gradient overlay as part of the same background-image stack
+            timerContent.style.backgroundImage = `linear-gradient(to bottom, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.85)), url('${backgroundImage}')`;
             timerContent.style.backgroundSize = 'cover';
             timerContent.style.backgroundPosition = 'center center';
             timerContent.style.backgroundRepeat = 'no-repeat';
             timerContent.style.backgroundAttachment = 'scroll';
+            timerContent.style.backgroundColor = 'rgba(255, 255, 255, 0.85)';
         } else {
             timerContent.style.backgroundImage = 'none';
             const bgColor = getCategoryGroupBg(task.category);

--- a/style.css
+++ b/style.css
@@ -595,15 +595,16 @@ textarea {
     gap: 10px;
 }
 
-.timer-content::before {
+.timer-content::after {
     content: '';
     position: absolute;
     top: 0;
     left: 0;
     right: 0;
     bottom: 0;
-    background: none;
+    background: linear-gradient(to bottom, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.85));
     border-radius: 8px;
+    z-index: 1;
     pointer-events: none;
 }
 

--- a/style.css
+++ b/style.css
@@ -604,7 +604,7 @@ textarea {
     bottom: 0;
     background: linear-gradient(to bottom, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.85));
     border-radius: 8px;
-    z-index: 1;
+    z-index: 0;
     pointer-events: none;
 }
 

--- a/style.css
+++ b/style.css
@@ -602,9 +602,8 @@ textarea {
     left: 0;
     right: 0;
     bottom: 0;
-    background: linear-gradient(to bottom, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.85));
+    background: none;
     border-radius: 8px;
-    z-index: 1;
     pointer-events: none;
 }
 

--- a/style.css
+++ b/style.css
@@ -602,9 +602,8 @@ textarea {
     left: 0;
     right: 0;
     bottom: 0;
-    background: linear-gradient(to bottom, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.85));
+    background: none;
     border-radius: 8px;
-    z-index: 0;
     pointer-events: none;
 }
 


### PR DESCRIPTION
### Purpose

The user wanted to fix an issue where the background images for tasks were not showing up on the timer.

### Code changes

- **script.js**: The `showTimer` function was updated to apply a `linear-gradient` overlay and the background image in a single `background-image` CSS property. This ensures the image is visible behind a semi-transparent overlay.
- **style.css**: The CSS overlay, which was previously implemented using a `::before` pseudo-element and was covering the background image, has been removed. The pseudo-element was changed to `::after` and its background was set to `none` to disable it.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/973e437a787b4fdda2bac24ce76015f4/cosmos-world)

👀 [Preview Link](https://973e437a787b4fdda2bac24ce76015f4-cosmos-world.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 47`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>973e437a787b4fdda2bac24ce76015f4</projectId>-->
<!--<branchName>cosmos-world</branchName>-->